### PR TITLE
suppress redefined function warning for unit test

### DIFF
--- a/lib/B/BUtils.pm
+++ b/lib/B/BUtils.pm
@@ -214,6 +214,8 @@ that.
 
 =cut
 
+no warnings "redefine";
+
 sub B::OP::parent {
     my $target = shift;
     printf( "parent %s %s=(0x%07x)\n",
@@ -255,6 +257,8 @@ sub B::OP::parent {
    $result = $search->($start) and return $result while $start = $start->next;
    return $search->($start);
 }
+
+use warnings "redefine";
 
 =item C<< $op->previous >>
 


### PR DESCRIPTION
`package_inside` methods returns array which contains warning message as below.
2nd element is warning, not package name.

```
Module::Info
Subroutine B::OP::parent redefined at blib/lib/B/BUtils.pm line 217.
Module::Info::Unsafe
Module::Info::Safe
```
